### PR TITLE
feat: Update hotwire-native-ios to 1.2

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -116,6 +116,15 @@ extension RNSession: SessionDelegate {
   func sessionDidFinishFormSubmission(_ session: Session) {
     visitableView?.didFinishFormSubmission()
   }
+
+  func session(_ session: Session, decidePolicyFor navigationAction: WKNavigationAction) -> WebViewPolicyManager.Decision {
+    guard let url = navigationAction.request.url else {
+      return .allow
+    }
+    // regardless of the return value here nothing happens, so we have to manually open external URL
+    visitableView?.didOpenExternalUrl(url: url)
+    return .allow
+  }
 }
 
 extension RNSession: WKScriptMessageHandler {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -175,10 +175,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   private func visit() {
-    if (controller?.visitableURL?.absoluteString == url as String) {
+    if (controller?.currentVisitableURL.absoluteString == url as String) {
       return
     }
-    controller!.visitableURL = URL(string: String(url))
+    controller!.initializeVisit(url: URL(string: String(url))!)
     session?.visit(controller!)
   }
 
@@ -218,7 +218,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
 
   public func didFailRequestForVisitable(visitable: Visitable, error: Error){
     let event: [AnyHashable: Any] = [
-      "url": visitable.visitableURL.absoluteString,
+      "url": visitable.currentVisitableURL.absoluteString,
       "description": error.localizedDescription,
       "statusCode": getStatusCodeFromError(error: error as? TurboError)
     ]

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -22,7 +22,7 @@
   "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index.tsx",
   "hotwireNative": {
-    "ios": "1.1.3",
+    "ios": "1.2.0",
     "android": "1.1.1"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

* update API changes that includes updating `visitableURL` to `initialVisitableURL` and `currentVisitableURL`. Related hotwire-native-ios PR: https://github.com/hotwired/hotwire-native-ios/pull/108
* introduce new method `.session(decidePolicyFor)` that opens external URL. We might consider making it more configurable with props but it's out of the scope of this PR. Related hotwire-native-ios PR: https://github.com/hotwired/hotwire-native-ios/pull/105 

## Test plan

* checked current demo web page and found no regressions. It doesn't provider bug with url change inside webview that this PR fixes, so it has to be tested on a different app