### PR TITLE
iOS: Fix `onLoad` not receiving the loaded URL

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -287,7 +287,7 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   func visitableDidRender(visitable: Visitable) {
     let event: [AnyHashable: Any] = [
       "title": webView!.title!,
-      "url": webView!.url!
+      "url": webView!.url!.absoluteString as Any,
     ]
     onLoad?(event)
   }


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `url` was not being properly casted on the iOS side, causing it to be `null` on the React Native side for the `onLoad` event.

## Test plan

The change can be tested by adding a log statement in the example app:

```js
const onLoad = useCallback(
    ({ title, url }: LoadEvent) => {
      navigation.setOptions({ title });
      console.log('onLoad', url);
    },
    [navigation]
  );
```

Before this change:

```
LOG  onLoad null
LOG  onLoad null
```

After this change:

```
LOG  onLoad https://turbo-native-demo.glitch.me/
LOG  onLoad https://turbo-native-demo.glitch.me/redirected
```
