### PR TITLE
Observe URL changes due to redirects and/or history changes 

### DIFF
--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -33,6 +33,7 @@
   RCT_EXPORT_VIEW_PROPERTY(onShowLoading, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onHideLoading, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onContentProcessDidTerminate, RCTDirectEventBlock)
+  RCT_EXPORT_VIEW_PROPERTY(onUrlChange, RCTDirectEventBlock)
 
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)

--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -21,17 +21,19 @@ const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
 
 class BridgeComponent extends Component<StradaComponentProps> {
   name: string;
-  url: string;
   sessionHandle: string;
   messageEventListenerSubscription?: EmitterSubscription;
   previousMessages: StradaMessages = {};
   registerMessageListener: (listener: (e: object) => void) => void;
   sendToBridge: (message: StradaMessage) => void;
 
+  get url(): string {
+    return this.props.url;
+  }
+
   constructor(props: StradaComponentProps) {
     super(props);
 
-    this.url = props.url;
     this.name = props.name;
     this.sessionHandle = props.sessionHandle;
     this.registerMessageListener = props.registerMessageListener;

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -21,6 +21,7 @@ import type {
   ContentProcessDidTerminateEvent,
   ContentInsetObject,
   ProgressViewOffsetObject,
+  UrlChangeEvent,
 } from './types';
 
 // Interface should match RNVisitableView exported properties in native code
@@ -41,6 +42,7 @@ export interface RNVisitableViewProps {
   onWebAlert?: (e: NativeSyntheticEvent<AlertHandler>) => void;
   onWebConfirm?: (e: NativeSyntheticEvent<AlertHandler>) => void;
   onOpenExternalUrl?: (e: NativeSyntheticEvent<OpenExternalUrlEvent>) => void;
+  onUrlChange?: (e: NativeSyntheticEvent<UrlChangeEvent>) => void;
   onFormSubmissionStarted?: (
     e: NativeSyntheticEvent<FormSubmissionEvent>
   ) => void;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useMemo,
   Component,
+  useState,
 } from 'react';
 import {
   NativeMethods,
@@ -119,6 +120,8 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       []
     );
 
+    const [currentUrl, setCurrentUrl] = useState(url);
+
     const {
       webViewStateComponent,
       handleShowLoading,
@@ -208,12 +211,18 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       [onContentProcessDidTerminate]
     );
 
+    const handleOnUrlChange = (event: NativeSyntheticEvent<URLChangeEvent>) => {
+      // A change of URL can happen from the native side if the WebView's url is changed, ie. as part
+      // of a redirect, a history push/pop action.
+      setCurrentUrl(event.nativeEvent.url);
+    };
+
     return (
       <>
         {stradaComponents?.map((StradaComponent, i) => (
           <StradaComponent
             key={`${url}-${i}`}
-            url={url}
+            url={currentUrl}
             sessionHandle={sessionHandle}
             name={StradaComponent.componentName}
             registerMessageListener={registerMessageListener}
@@ -242,6 +251,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           onFormSubmissionFinished={handleOnFormSubmissionFinished}
           onShowLoading={handleShowLoading}
           onHideLoading={handleHideLoading}
+          onUrlChange={handleOnUrlChange}
           onContentProcessDidTerminate={handleOnContentProcessDidTerminate}
           style={style}
         />

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -22,6 +22,10 @@ export interface ContentProcessDidTerminateEvent {
   url: string;
 }
 
+export interface UrlChangeEvent {
+  url: string;
+}
+
 export type MessageEvent = object;
 
 export interface AlertHandler {


### PR DESCRIPTION
## Summary

For Strada Bridge Components, we ignore messages being sent unless the `url` match where the Strada Component was originally mounted. `url` is a controlled prop on the React Native side.

This causes issues when a Turbo Frame has changed the `document.location` of the WebView to something else (ie. with `data-turbo-action="replace"`), as the `document.location` is not out-of-sync with the `url` prop on the RN side, which is used to detect if messages sent via Strada bridge should be ignored or taken action on.

In order to make sure that we know the current URL of the WebView in React Native land, we can observe the `webView.url` value on the native side, and let the RN side know that it has changed due to eg. history pushes or redirects.

## Test plan

In order to test it, we need to have a Turbo Frame with `data-turbo-action="replace"` as well as a Strada component on the replaced content page.

I've created a branch on the demo web app that contains this: https://github.com/pfeiffer/turbo-native-demo/tree/test-turbo-frame-redirects

This can be checked out and the demo app pointed to the local running version of the test server.

### Before

https://github.com/user-attachments/assets/588eb3e1-3fa1-4e7c-9b04-52c2eb52f8dc

### After

https://github.com/user-attachments/assets/597f7e7e-20d5-4e44-bb14-e93b8bdab608


