### PR TITLE
Fix: BridgeComponents and sync iOS URL after frame navigations

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -104,6 +104,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
 
   private func startObservingWebViewUrl() {
     stopObservingWebViewUrl()
+
+    // This helps ensure pull-to-refresh refreshes the correct URL after Turbo Frame navigations.
+    // Currently, this does not trigger an `onLoad` on the JS side — iOS needs this workaround,
+    // while Android handles pull-to-refresh correctly without it.
+    // Consider triggering `onLoad` if a cross-platform solution is found.
     webViewUrlObservation = webView?.observe(\.url, options: [.new]) { [weak self] webView, change in
             guard let self = self,
                   let newUrl = change.newValue ?? nil,

--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -5,14 +5,12 @@ import type {
   StradaMessage,
   StradaMessages,
   StradaComponentProps,
+  SessionMessageCallback,
 } from './types';
 
 const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
   const message = e as StradaMessage;
-  if (
-    message?.component !== component.name ||
-    message?.data?.metadata?.url !== component.url
-  ) {
+  if (message?.component !== component.name) {
     return;
   }
   component.previousMessages[message.event] = message;
@@ -25,7 +23,9 @@ class BridgeComponent extends Component<StradaComponentProps> {
   sessionHandle: string;
   messageEventListenerSubscription?: EmitterSubscription;
   previousMessages: StradaMessages = {};
-  registerMessageListener: (listener: (e: object) => void) => void;
+  registerMessageListener: (
+    listener: SessionMessageCallback
+  ) => EmitterSubscription;
   sendToBridge: (message: StradaMessage) => void;
 
   constructor(props: StradaComponentProps) {
@@ -42,7 +42,9 @@ class BridgeComponent extends Component<StradaComponentProps> {
   }
 
   componentDidMount() {
-    this.registerMessageListener(stradaMessageListener(this));
+    this.messageEventListenerSubscription = this.registerMessageListener(
+      stradaMessageListener(this)
+    );
   }
 
   componentWillUnmount() {

--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -1,11 +1,11 @@
 import { Component } from 'react';
-import type { EmitterSubscription } from 'react-native';
 
 import type {
   StradaMessage,
   StradaMessages,
   StradaComponentProps,
   SessionMessageCallback,
+  EventSubscription,
 } from './types';
 
 const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
@@ -21,11 +21,11 @@ class BridgeComponent extends Component<StradaComponentProps> {
   name: string;
   url: string;
   sessionHandle: string;
-  messageEventListenerSubscription?: EmitterSubscription;
+  messageEventListenerSubscription?: EventSubscription;
   previousMessages: StradaMessages = {};
   registerMessageListener: (
     listener: SessionMessageCallback
-  ) => EmitterSubscription;
+  ) => EventSubscription;
   sendToBridge: (message: StradaMessage) => void;
 
   constructor(props: StradaComponentProps) {

--- a/packages/turbo/src/hooks/useMessageQueue.ts
+++ b/packages/turbo/src/hooks/useMessageQueue.ts
@@ -15,6 +15,14 @@ export function useMessageQueue(
   const registerMessageListener = useCallback(
     (listener: SessionMessageCallback) => {
       onMessageCallbacks.current.push(listener);
+
+      return {
+        remove: () => {
+          onMessageCallbacks.current = onMessageCallbacks.current.filter(
+            (callback) => callback !== listener
+          );
+        },
+      };
     },
     []
   );

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -1,3 +1,5 @@
+import { EmitterSubscription } from "react-native";
+
 export type Action = 'advance' | 'replace' | 'restore';
 
 export interface VisitProposal {
@@ -76,7 +78,7 @@ export type StradaComponentProps = {
   sessionHandle: string;
   url: string;
   name: string;
-  registerMessageListener: (listener: SessionMessageCallback) => void;
+  registerMessageListener: (listener: SessionMessageCallback) => EmitterSubscription;
   sendToBridge: (message: StradaMessage) => void;
 };
 

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -1,5 +1,3 @@
-import { EmitterSubscription } from "react-native";
-
 export type Action = 'advance' | 'replace' | 'restore';
 
 export interface VisitProposal {
@@ -74,11 +72,17 @@ export type SessionMessageCallback = (message: object) => void;
 
 export type OnErrorCallback = (error: ErrorEvent) => void;
 
+export type EventSubscription = {
+  remove: () => void;
+};
+
 export type StradaComponentProps = {
   sessionHandle: string;
   url: string;
   name: string;
-  registerMessageListener: (listener: SessionMessageCallback) => EmitterSubscription;
+  registerMessageListener: (
+    listener: SessionMessageCallback
+  ) => EventSubscription;
   sendToBridge: (message: StradaMessage) => void;
 };
 


### PR DESCRIPTION
## Summary

This PR provides a comprehensive fix for issues with Strada Bridge Components that occur after Turbo Frame navigations or redirects. It ensures that components remain active and that native iOS state remains synchronized, correcting functionality like pull-to-refresh.

This PR addresses two problems - #228 and iOS Pull-to-Refresh regression. To fix the iOS regression, this PR introduces an approach similar to what was mentioned in #227 - it has been resolved by adding a Key-Value Observer to the WKWebView's url property in RNVisitableView.swift. This restores pull-to-refresh and ensures native state consistency. 

## Test plan

We can test both Bridge components and pull-to-refresh functionalities work as expected by using the specific branch of the demo server.

This [branch](https://github.com/pfeiffer/turbo-native-demo/tree/test-turbo-frame-redirects?rgh-link-date=2025-05-14T10%3A44%3A15Z) of the demo web app includes Strada Components flow that can be used to test them.

This can be checked out and the demo app pointed to the local running version of the test server.

## Demo

Functionalities tested on [this version](https://github.com/pfeiffer/turbo-native-demo/tree/test-turbo-frame-redirects?rgh-link-date=2025-05-14T10%3A44%3A15Z) of demo web app.

https://github.com/user-attachments/assets/0e45133e-bc4e-4e90-b9af-9fc2696118c6

